### PR TITLE
Move the discussion of WCAG success criteria relevant to the real-time aspects of a meeting to the section on meeting platform accessibility.

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,13 @@
 <section>
 <h4>Relevance of the Web Content Accessibility Guidelines</h4>
 <p>Guidance in the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a> [[wcag21]] standard applies to user interface elements in remote meeting software.</p>
+<p><strong>Live audio and video communications that take place among meeting participants are also subject to the Web content Accessibility Guidelines.</strong> These are the real-time communication components of the meeting. The following WCAG 2.1 success criteria provide support for accessibility of live audio and video:</p>
+<ul>
+<li>Success Criterion 1.2.4: Captions (Live). This is applicable to real-time communication by meeting participants. The quality of captions is essential to effective communication. It should be noted that the use of automatic speech recognition (ASR) technology to generate captions will not yield sufficiently high quality without manual intervention to correct errors. Moreover, such correction is difficult to perform effectively in real time. In addition, live captioning can help people with cognitive disabilities by providing a transcript that can be reviewed as needed. Participants should be asked prior to the meeting if manual captioning is required.</li>
+<li>Success criterion 1.2.9: Audio-only (Live). This success criterion specifies that a text transcript of live, audio-only content be provided. In a meeting. This could be achieved by transcribing the dialogue in real time. As with captions of videoconferences, automatic speech recognition will not yield sufficiently high quality captions for most settings.</li>
+<li>For user interfaces presented live in a meeting via screen sharing: success criteria 1.4.1 (Use of color), 1.4.3 (text contrast), 1.4.6 (contrast - enhanced), 2.3.1 (three flashes or below threshold), 2.3.2 (three flashes) are applicable.</li>
+</ul>
+<p class="note">Sign language interpretation greatly facilitates accessibility of meetings for sign language users. Sign language interpretation is a Level AAA requirement of WCAG 2.1 for prerecorded audio content only. However, sign language can be streamed into a videoconference window during a live videoconferencing session; this may need clarification in future versions of the Guidelines.</p>
 </section>
 <section>
 <h4>Relevance of the User Agent Accessibility Guidelines</h4>
@@ -158,16 +165,7 @@
   <h3>W3C guidance relevant for accessible remote meetings</h3>
   <section>
 <h4>Relevance of the Web Content Accessibility Guidelines</h4>
-<ul>
-<li><strong>Any prepared content (e.g., documents, presentation slides, prerecorded multimedia) that is shared with or shown to meeting participants is subject to the Web Content Accessibility Guidelines (WCAG).</strong> Policies typically specify that documents, presentations and related materials should conform to WCAG 2.1 Level AA.</li>
-<li><strong>Live audio and video communications that take place among meeting participants.</strong> This is the real-time communication component of the meeting. The following WCAG 2.1 success criteria provide support for accessibility of live audio and video:
-<ul>
-<li>Success Criterion 1.2.4: Captions (Live). This is applicable to real-time communication by meeting participants. The quality of captions is essential to effective communication. It should be noted that the use of automatic speech recognition (ASR) technology to generate captions will not yield sufficiently high quality without manual intervention to correct errors. Moreover, such correction is difficult to perform effectively in real time. In addition, live captioning can help people with cognitive disabilities by providing a transcript that can be reviewed as needed. Participants should be asked prior to the meeting if manual captioning is required.</li>
-<li>Success criterion 1.2.9: Audio-only (Live). This success criterion specifies that a text transcript of live, audio-only content be provided. In a meeting. This could be achieved by transcribing the dialogue in real time. As with captions of videoconferences, automatic speech recognition will not yield sufficiently high quality captions for most settings.</li>
-<li>For user interfaces presented live in a meeting via screen sharing: success criteria 1.4.1 (Use of color), 1.4.3 (text contrast), 1.4.6 (contrast - enhanced), 2.3.1 (three flashes or below threshold), 2.3.2 (three flashes) are applicable.</li>
-</ul></li>
-</ul>
-<p>Note: sign language interpretation greatly facilitates accessibility of meetings for sign language users. Sign language interpretation is a Level AAA requirement of WCAG 2.1 for prerecorded audio content only. However, sign language can be streamed into a videoconference window during a live videoconferencing session; this may need clarification in future versions of the Guidelines.</p>
+<p><strong>Any prepared content (e.g., documents, presentation slides, prerecorded multimedia) that is shared with or shown to meeting participants is subject to the Web Content Accessibility Guidelines (WCAG).</strong> Policies typically specify that documents, presentations and related materials should conform to WCAG 2.1 Level AA.</p>
   </section>
   <section>
 <h4>Relevance of the Authoring Tool Accessibility Guidelines (ATAG)</h4>


### PR DESCRIPTION
Closes #6.
